### PR TITLE
Update curate-chain.test.ts

### DIFF
--- a/tests/curate-chain.test.ts
+++ b/tests/curate-chain.test.ts
@@ -1,21 +1,59 @@
-
 import { describe, expect, it } from "vitest";
 
+// Get test accounts from the simnet
 const accounts = simnet.getAccounts();
 const address1 = accounts.get("wallet_1")!;
 
-/*
-  The test below is an example. To learn more, read the testing documentation here:
-  https://docs.hiro.so/stacks/clarinet-js-sdk
-*/
-
-describe("example tests", () => {
+describe("CurateChain Tests", () => {
   it("ensures simnet is well initialised", () => {
     expect(simnet.blockHeight).toBeDefined();
   });
 
-  // it("shows an example", () => {
-  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
-  //   expect(result).toBeUint(0);
-  // });
+  it("applies time-weighted reputation decay for a participant", () => {
+    // Submit a content item first to have some credibility
+    let submission = simnet.call(
+      "curate-chain",
+      "contribute-item",
+      [
+        `(string-ascii "Test Headline")`,
+        `(string-ascii "https://example.com/article")`,
+        `(string-ascii "Technology")`
+      ],
+      address1
+    );
+    expect(submission.result).toBeOk();
+
+    // Give the participant a positive appraisal to increase credibility
+    let appraisal = simnet.call(
+      "curate-chain",
+      "appraise-item",
+      [
+        `(uint 1)`, // item-identifier
+        `(int 1)`   // appraisal +1
+      ],
+      address1
+    );
+    expect(appraisal.result).toBeOk();
+
+    // Call the decay function to apply time-weighted reduction
+    let decay = simnet.call(
+      "curate-chain",
+      "decay-participant-credibility",
+      [
+        `(principal ${address1})`
+      ],
+      address1
+    );
+    expect(decay.result).toBeOk();
+
+    // Read the participant's credibility after decay
+    let credibility = simnet.callReadOnlyFn(
+      "curate-chain",
+      "retrieve-participant-credibility",
+      [`(principal ${address1})`],
+      address1
+    );
+    expect(credibility.result).toBeDefined();
+    expect(credibility.result).toBeIntLessThanOrEqual(1); // credibility should have decayed
+  });
 });


### PR DESCRIPTION
Add Clarinet test for CurateChain time-weighted reputation decay

- Ensures simnet initialization works
- Submits a content item and appraises it
- Applies time-weighted decay to participant credibility
- Verifies credibility value decreases